### PR TITLE
fix: epss score dates invalid due to utc and limiting query by last_seen

### DIFF
--- a/code/reporter/slack_report.py
+++ b/code/reporter/slack_report.py
@@ -5,6 +5,7 @@ from slackblocks import (
     DividerBlock,
     SectionBlock,
     RichTextBlock,
+    RichTextLink,
     Message,
 )
 from slackblocks.rich_text import RichTextSection, RichTextList, ListType, RichText
@@ -67,6 +68,7 @@ class SlackSecurityReport:
             elements=[
                 RichTextList(
                     style=ListType.BULLET,
+                    indent=1,
                     elements=[
                         RichTextSection(
                             elements=[
@@ -82,11 +84,16 @@ class SlackSecurityReport:
             kev_vuln_block.elements.append(
                 RichTextList(
                     style=ListType.BULLET,
+                    indent=1,
                     elements=[
                         RichTextSection(
                             elements=[
+                                RichTextLink(
+                                    text=f"{x.cve}",
+                                    url=f"https://www.cvedetails.com/cve/{x.cve}"
+                                ),
                                 RichText(
-                                    text=f"{x.cve} present across {str(x.num_env)} AWS Accounts"
+                                    text=f" present across {str(x.num_env)} AWS Accounts"
                                 )
                             ]
                         )
@@ -119,11 +126,16 @@ class SlackSecurityReport:
             epss_vuln_block.elements.append(
                 RichTextList(
                     style=ListType.BULLET,
+                    indent=1,
                     elements=[
                         RichTextSection(
                             elements=[
+                                RichTextLink(
+                                    text=f"{x.cve}",
+                                    url=f"https://www.cvedetails.com/cve/{x.cve}"
+                                ),
                                 RichText(
-                                    text=f"{x.cve} present across {str(x.num_env)} AWS Accounts"
+                                    text=f" present across {str(x.num_env)} AWS Accounts"
                                 )
                             ]
                         )


### PR DESCRIPTION
Changes
- When hitting the EPSS endpoint, UTC time will cause the lambda to ask for EPSS scores for a day in the future, resulting in a 403
- Fixed Nessus query to limit on `LAST_SEEN`
- Adds CVE Details links to CVEs found for easier triage